### PR TITLE
Fix device storage menu when using Adopted Storage

### DIFF
--- a/src/com/android/settings/deviceinfo/PrivateVolumeSettings.java
+++ b/src/com/android/settings/deviceinfo/PrivateVolumeSettings.java
@@ -162,7 +162,8 @@ public class PrivateVolumeSettings extends SettingsPreferenceFragment {
         mVolume = mStorageManager.findVolumeById(mVolumeId);
 
         final long sharedDataSize = mVolume.getPath().getTotalSpace();
-        mTotalSize = getArguments().getLong(EXTRA_VOLUME_SIZE, 0);
+        boolean isInternal = VolumeInfo.ID_PRIVATE_INTERNAL.equals(mVolume.getId());
+        mTotalSize = isInternal ? getArguments().getLong(EXTRA_VOLUME_SIZE, 0) : sharedDataSize;
         mSystemSize = mTotalSize - sharedDataSize;
         if (mTotalSize <= 0) {
             mTotalSize = sharedDataSize;

--- a/src/com/android/settings/deviceinfo/StorageSettings.java
+++ b/src/com/android/settings/deviceinfo/StorageSettings.java
@@ -166,13 +166,15 @@ public class StorageSettings extends SettingsPreferenceFragment implements Index
         for (VolumeInfo vol : volumes) {
             if (vol.getType() == VolumeInfo.TYPE_PRIVATE) {
                 final int color = COLOR_PRIVATE[privateCount++ % COLOR_PRIVATE.length];
+                boolean isInternal = VolumeInfo.ID_PRIVATE_INTERNAL.equals(vol.getId());
+                long size = isInternal ? sTotalInternalStorage : vol.getPath().getTotalSpace();
                 mInternalCategory.addPreference(
-                        new StorageVolumePreference(context, vol, color, sTotalInternalStorage));
+                        new StorageVolumePreference(context, vol, color, size));
                 if (vol.isMountedReadable()) {
                     final File path = vol.getPath();
                     privateUsedBytes += path.getTotalSpace() - path.getFreeSpace();
-                    if (sTotalInternalStorage > 0) {
-                        privateTotalBytes = sTotalInternalStorage;
+                    if (isInternal && sTotalInternalStorage > 0) {
+                        privateTotalBytes += sTotalInternalStorage;
                     } else {
                         privateTotalBytes += path.getTotalSpace();
                     }
@@ -503,8 +505,8 @@ public class StorageSettings extends SettingsPreferenceFragment implements Index
                 if (path == null) {
                     continue;
                 }
-                if (info.getType() == VolumeInfo.TYPE_PRIVATE && sTotalInternalStorage > 0) {
-                    privateTotalBytes = sTotalInternalStorage;
+                if (VolumeInfo.ID_PRIVATE_INTERNAL.equals(info.getId()) && sTotalInternalStorage > 0) {
+                    privateTotalBytes += sTotalInternalStorage;
                 } else {
                     privateTotalBytes += path.getTotalSpace();
                 }


### PR DESCRIPTION
* Commits ff162a3, 7dfc8df changed the behavior so that
  adapted storage in UI would use size from internal storage.
  Let's bring back some sanity and fix it :3

Change-Id: I2a835687270cfaba81331d559b83316d73365b8c